### PR TITLE
fix(fences): connection to logic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ plugins {
 apply plugin: "se.bjurr.gitchangelog.git-changelog-gradle-plugin"
 apply plugin: 'forge'
 
-version = "2.0.26"
+version = "2.0.27"
 if (System.getenv("BUILD_NUMBER") != null) {
     version = version + "." + System.getenv("BUILD_NUMBER")
 }

--- a/src/main/java/binnie/extratrees/block/decor/BlockFence.java
+++ b/src/main/java/binnie/extratrees/block/decor/BlockFence.java
@@ -1,6 +1,5 @@
 package binnie.extratrees.block.decor;
 
-import binnie.core.Mods;
 import binnie.core.block.BlockMetadata;
 import binnie.core.block.IBlockMetadata;
 import binnie.core.block.TileEntityMetadata;
@@ -19,7 +18,6 @@ import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
-import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
@@ -39,15 +37,6 @@ public class BlockFence extends net.minecraft.block.BlockFence implements IBlock
 		setResistance(5.0f);
 		setHardness(2.0f);
 		setStepSound(Block.soundTypeWood);
-	}
-
-	public static boolean canConnect(Block block) {
-		return block == ((ItemBlock) Mods.forestry.item("fences")).field_150939_a
-			|| block == Blocks.fence
-			|| block == Blocks.fence_gate
-			|| block == Blocks.nether_brick_fence
-			|| block instanceof IBlockFence
-			|| block == ExtraTrees.blockGate;
 	}
 
 	@Override
@@ -146,16 +135,10 @@ public class BlockFence extends net.minecraft.block.BlockFence implements IBlock
 
 	@Override
 	public boolean canConnectFenceTo(IBlockAccess world, int x, int y, int z) {
-		if (!isFence(world, x, y, z)) {
-			Block block = world.getBlock(x, y, z);
-			return block != null && block.getMaterial().isOpaque() && block.renderAsNormalBlock();
-		}
-		return true;
-	}
-
-	public boolean isFence(IBlockAccess world, int x, int y, int z) {
 		Block block = world.getBlock(x, y, z);
-		return canConnect(block);
+		Material material = block.getMaterial();
+		return IBlockFence.isFence(block) && material == this.blockMaterial
+			|| material.isOpaque() && block.renderAsNormalBlock() && material != Material.gourd;
 	}
 
 	@Override

--- a/src/main/java/binnie/extratrees/block/decor/BlockHedge.java
+++ b/src/main/java/binnie/extratrees/block/decor/BlockHedge.java
@@ -29,10 +29,6 @@ public class BlockHedge extends Block implements IBlockFence {
 		setBlockName("hedge");
 	}
 
-	public static boolean func_149825_a(Block block) {
-		return BlockFence.canConnect(block);
-	}
-
 	public static int getColor(int meta) {
 		LeafType type = LeafType.values()[meta % 6];
 		if (type == LeafType.CONIFER) {
@@ -130,11 +126,11 @@ public class BlockHedge extends Block implements IBlockFence {
 		return ModuleBlocks.hedgeRenderID;
 	}
 
+	@Override
 	public boolean canConnectFenceTo(IBlockAccess world, int x, int y, int z) {
 		Block block = world.getBlock(x, y, z);
 		return block == this
-			|| block == Blocks.fence_gate
-			|| func_149825_a(block)
+			|| IBlockFence.isFence(block)
 			|| block.isLeaves(world, x, y, z)
 			|| (block.getMaterial().isOpaque() && block.renderAsNormalBlock() && block.getMaterial() != Material.gourd);
 	}

--- a/src/main/java/binnie/extratrees/block/decor/IBlockFence.java
+++ b/src/main/java/binnie/extratrees/block/decor/IBlockFence.java
@@ -1,4 +1,26 @@
 package binnie.extratrees.block.decor;
 
+import binnie.core.Mods;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockFence;
+import net.minecraft.block.BlockFenceGate;
+import net.minecraft.init.Blocks;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.world.IBlockAccess;
+
 public interface IBlockFence {
+
+    /**
+     * Test if the specified block is a fence
+     *
+     * @param block the block to test
+     * @return {@code true} if the specified block is a fence
+     */
+    static boolean isFence(Block block) {
+        return block == ((ItemBlock) Mods.forestry.item("fences")).field_150939_a
+                || block instanceof BlockFence && block != Blocks.nether_brick_fence
+                || block instanceof BlockFenceGate;
+    }
+
+    boolean canConnectFenceTo(IBlockAccess world, int x, int y, int z);
 }


### PR DESCRIPTION
Fix ExtraTrees fences to connect correctly to other wooden fences and fence gates.
    
Address issue: [Extra Trees fences are buggy #5694](https://github.com/GTNewHorizons/NewHorizons/issues/5694)
    
Works even better with https://github.com/mitchej123/Hodgepodge/pull/2 witch patches vanilla fences to connect with other mod fences.

![Screenshot](https://i.imgur.com/uiZ5BzP.png)

