### PR TITLE
Fix Extra Trees fences and gates showing up wrong in WAILA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /run
 /eclipse
 /out
+/bin
 /classes
 .idea
 *.iml

--- a/src/main/java/binnie/extratrees/block/decor/BlockFence.java
+++ b/src/main/java/binnie/extratrees/block/decor/BlockFence.java
@@ -174,6 +174,13 @@ public class BlockFence extends net.minecraft.block.BlockFence implements IBlock
 	}
 
 	@Override
+	//@SideOnly(Side.CLIENT)
+	public ItemStack getPickBlock(MovingObjectPosition target, World world, int x, int y, int z) {
+		return BlockMetadata.getPickBlock(world, x, y, z);
+	}
+
+	@Override
+	//@SideOnly(Side.CLIENT)
 	public ItemStack getPickBlock(MovingObjectPosition target, World world, int x, int y, int z, EntityPlayer player) {
 		return BlockMetadata.getPickBlock(world, x, y, z);
 	}

--- a/src/main/java/binnie/extratrees/block/decor/BlockGate.java
+++ b/src/main/java/binnie/extratrees/block/decor/BlockGate.java
@@ -137,6 +137,13 @@ public class BlockGate extends BlockFenceGate implements IBlockMetadata {
 	}
 
 	@Override
+	//@SideOnly(Side.CLIENT)
+	public ItemStack getPickBlock(MovingObjectPosition target, World world, int x, int y, int z) {
+		return BlockMetadata.getPickBlock(world, x, y, z);
+	}
+
+	@Override
+	//@SideOnly(Side.CLIENT)
 	public ItemStack getPickBlock(MovingObjectPosition target, World world, int x, int y, int z, EntityPlayer player) {
 		return BlockMetadata.getPickBlock(world, x, y, z);
 	}


### PR DESCRIPTION
Partially fixes GTNewHorizons/NewHorizons#5694.

The underlying problem here lies within WAILA: WAILA uses the deprecated `Block.getPickBlock(MovingObjectPosition target, World world, int x, int y, int z)` method to get the block the user is currently pointing at ([source link](https://github.com/GTNewHorizons/waila/blob/07b0b83f4ac35e3a01a0c0e679306c89c6942e35/src/main/java/mcp/mobius/waila/overlay/RayTracing.java#L209)). However, Extra Trees expected the `Block.getPickBlock(MovingObjectPosition target, World world, int x, int y, int z, EntityPlayer player)` method to be used (which is not deprecated) and thus implemented that for custom handling required for the ET fences and gates. Rather than fix WAILA to use the non-deprecated method we add the additional methods to Extra Trees. Reason being, that it could break other blocks that only implement the deprecated method and this change to ET is pretty small. If there are more issues found in the future with WAILA showing wrong blocks, we can still implement a fix there.