### PR TITLE
ExtraTrees' Butterfly crashing on Escritoire

### DIFF
--- a/src/main/java/binnie/extratrees/genetics/ButterflySpecies.java
+++ b/src/main/java/binnie/extratrees/genetics/ButterflySpecies.java
@@ -213,7 +213,7 @@ public enum ButterflySpecies implements IAlleleButterflySpecies {
 		if (itemstack.getItem() == Mods.forestry.item("honeydew")) {
 			return 0.7f;
 		}
-		if (itemstack.getItem() == Mods.forestry.item("beeComb")) {
+		if (itemstack.getItem() == Mods.forestry.item("beeCombs")) {
 			return 0.4f;
 		}
 		if (AlleleManager.alleleRegistry.isIndividual(itemstack)) {


### PR DESCRIPTION
Researching Extra Tree's Butterflies with honeycombs causes a crash when inserting a beecomb since the item name is **Forestry:beeCombs**:

> java.lang.RuntimeException: Item not found: Forestry:beeComb
> 	at binnie.core.Mods.findItem(Mods.java:17)

![image](https://user-images.githubusercontent.com/47131096/146481181-f5c61c3d-edf5-4746-90dc-d4c34c304dba.png)
