### PR TITLE
Fix Volcanic Branch Bees

### DIFF
--- a/src/main/java/binnie/extrabees/genetics/ExtraBeeBranchDefinition.java
+++ b/src/main/java/binnie/extrabees/genetics/ExtraBeeBranchDefinition.java
@@ -179,6 +179,7 @@ public enum ExtraBeeBranchDefinition implements IBranchDefinition {
 	VOLCANIC("Irrapis") {
 		@Override
 		protected void setBranchProperties(IAllele[] template) {
+			AlleleHelper.instance.set(template, EnumBeeChromosome.NOCTURNAL, true);
 			AlleleHelper.instance.set(template, EnumBeeChromosome.SPEED, EnumAllele.Speed.SLOWER);
 			AlleleHelper.instance.set(template, EnumBeeChromosome.LIFESPAN, EnumAllele.Lifespan.NORMAL);
 			AlleleHelper.instance.set(template, EnumBeeChromosome.EFFECT, AlleleHelper.getAllele(ExtraBeesEffect.METEOR.getUID()));


### PR DESCRIPTION
Volcanic branch (from Nether hives) should natively work in the Nether but don't from erroneously lacking the nocturnal species trait:
https://ftb.fandom.com/wiki/Embittered_Bee

This effectively create a case where this bee must only be in the Nether to work but can never be able to actually work in it from lack of daytime.