### PR TITLE
Fix frame overrides not respecting `maxDamage` field

### DIFF
--- a/src/main/java/binnie/extrabees/apiary/ItemHiveFrame.java
+++ b/src/main/java/binnie/extrabees/apiary/ItemHiveFrame.java
@@ -27,6 +27,11 @@ public class ItemHiveFrame extends Item implements IHiveFrame, IBeeModifier {
     }
 
     @Override
+    public int getMaxDamage() {
+        return frame.maxDamage;
+    }
+
+    @Override
     public String getItemStackDisplayName(ItemStack stack) {
         return frame.getName();
     }


### PR DESCRIPTION
Fixes ExtraBees frames not respecting an internal `maxDamage` setter. This resulted in the Soul Frame claiming to have 80 durability, but actually having the default durability of 240.