### PR TITLE
Fix Swamp Gum Tree

### DIFF
--- a/src/main/java/binnie/extratrees/genetics/ExtraTreeSpecies.java
+++ b/src/main/java/binnie/extratrees/genetics/ExtraTreeSpecies.java
@@ -564,7 +564,7 @@ public enum ExtraTreeSpecies implements IAlleleTreeSpecies, IIconProvider, IGerm
                 .setMaturation(EnumAllele.Maturation.SLOWEST);
 
         ExtraTreeSpecies.SwampGum.addFamily(familyJungle).setLeafType(LeafType.JUNGLE)
-                .setHeight(EnumAllele.Height.SMALLEST).setFertility(EnumAllele.Saplings.LOWEST)
+                .setHeight(EnumAllele.Height.LARGEST).setFertility(EnumAllele.Saplings.LOWEST)
                 .setMaturation(EnumAllele.Maturation.SLOWER).setGirth(2);
 
         ExtraTreeSpecies.Box.addFamily(familyPome).addFamily(familyPrune).addFamily(familyNuts).addFamily(familyCitrus)


### PR DESCRIPTION
Reverts Swamp Gum stats to that of 1.6.4.

**Why?**

Here is a Swamp Gum in 1.6.4 with Binnie version 1.8.0:
![image](https://github.com/GTNewHorizons/Binnie/assets/47131096/2e5730d7-61a6-4c3c-983f-f65186c67ba7)
and now, the new gloriously updated version in 1.7.10:
![image](https://github.com/GTNewHorizons/Binnie/assets/47131096/2d9a47fc-3cdd-4766-8df4-ae845882e7c2)
if you are lucky you may also get leaves on it (1 or even a whole 2 leaves if exceptionally lucky):
![image](https://github.com/GTNewHorizons/Binnie/assets/47131096/2ac1c5b9-97c7-4686-97b5-968d7c94add8)

While I understand that the Swamp Gum Tree is on the smaller side of the eucalyptus tree and while it makes sense to make it the smallest size, its tree generation mutilates it into something far more comically eerie than its real counterpart:
![image](https://github.com/GTNewHorizons/Binnie/assets/47131096/63672323-8e87-49be-9a4d-222dfba4e284)

I reverted the stats based on the treealyzer output in the 1.6.4 test version.
Here's a screenshot to it:
![image](https://github.com/GTNewHorizons/Binnie/assets/47131096/d5988d91-526f-4271-827c-649ced2bb5ad)

If anyone wants to debate why this should be kept and indeed classified as a leafless tree I would love to hear your argument

