### PR TITLE
Fixed the stimulator accepting stacks with a size higher than 1

### DIFF
--- a/src/main/java/binnie/core/machines/transfer/TransferRequest.java
+++ b/src/main/java/binnie/core/machines/transfer/TransferRequest.java
@@ -149,9 +149,17 @@ public class TransferRequest {
                         if (destination.getStackInSlot(slot) == null) {
                             insertedSlots.add(new TransferSlot(slot, destination));
                             if (doAdd) {
-                                destination.setInventorySlotContents(slot, item.copy());
+                                ItemStack movedStack = item.copy();
+                                if (movedStack.stackSize > destination.getInventoryStackLimit()) {
+                                    movedStack.stackSize = destination.getInventoryStackLimit();
+                                }
+                                item.stackSize -= movedStack.stackSize;
+                                destination.setInventorySlotContents(slot, movedStack);
+                                if (item.stackSize <= 0) {
+                                    item = null;
+                                }
                             }
-                            return null;
+                            return item;
                         }
                     }
                 }

--- a/src/main/java/binnie/extrabees/apiary/machine/stimulator/StimulatorAlvearyPackage.java
+++ b/src/main/java/binnie/extrabees/apiary/machine/stimulator/StimulatorAlvearyPackage.java
@@ -18,7 +18,13 @@ public class StimulatorAlvearyPackage extends AlvearyMachine.AlvearyPackage impl
     @Override
     public void createMachine(Machine machine) {
         new ComponentExtraBeeGUI(machine, ExtraBeeGUID.AlvearyStimulator);
-        ComponentInventorySlots inventory = new ComponentInventorySlots(machine);
+        ComponentInventorySlots inventory = new ComponentInventorySlots(machine) {
+
+            @Override
+            public int getInventoryStackLimit() {
+                return 1;
+            }
+        };
         inventory.addSlot(AlvearyStimulator.SLOT_CIRCUIT, "circuit");
         inventory.getSlot(AlvearyStimulator.SLOT_CIRCUIT).setValidator(new CircuitSlotValidator());
         new ComponentPowerReceptor(machine);


### PR DESCRIPTION
You can insert a stack of multiple circuits into the electrical stimulator. However it doesn't have any effect to add more than 1 into a single stimulator. This is misleading and makes it a bit more annoying when putting a stack of circuits into multiple stims, since you need to break the stack beforehand.