### PR TITLE
Fix Incubator breaking with item outputs

### DIFF
--- a/src/main/java/binnie/core/machines/transfer/TransferRequest.java
+++ b/src/main/java/binnie/core/machines/transfer/TransferRequest.java
@@ -122,7 +122,7 @@ public class TransferRequest {
                             || ((IInventorySlots) destination).getSlot(slot) == null
                             || !((IInventorySlots) destination).getSlot(slot).isRecipe()) {
                         if (destination.getStackInSlot(slot) != null) {
-                            if (item.isStackable()) {
+                            if (item.isStackable() && destination.getInventoryStackLimit() > 1) {
                                 ItemStack merged = destination.getStackInSlot(slot).copy();
                                 ItemStack[] newStacks = mergeStacks(item.copy(), merged.copy());
                                 item = newStacks[0];
@@ -158,8 +158,9 @@ public class TransferRequest {
                                 if (item.stackSize <= 0) {
                                     item = null;
                                 }
+                                return item;
                             }
-                            return item;
+                            return null;
                         }
                     }
                 }


### PR DESCRIPTION
Alright this took a few breakpoints to figure out.. The incubator expects a null response during its roomforOutput check, but that was never getting set to null.
Moving `return item;` into the doAdd check seems to have fixed it.

I also added `destination.getInventoryStackLimit() > 1)` to the transfer requests merge stack check, so you can no longer stack circuit boards in the stimulator with shift click.

Stimulator correctly accepts 1 item under any circumstance and doesn't void the remainder anymore (both with and without shift click).
Incubator happily gets its null response and will continue its work from there.

Closes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13885