### PR TITLE
NEI item manager overlay integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1691351470
+//version: 1695474595
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -89,6 +89,23 @@ def out = services.get(StyledTextOutputFactory).create('an-output')
 def projectJavaVersion = JavaLanguageVersion.of(8)
 
 boolean disableSpotless = project.hasProperty("disableSpotless") ? project.disableSpotless.toBoolean() : false
+boolean disableCheckstyle = project.hasProperty("disableCheckstyle") ? project.disableCheckstyle.toBoolean() : false
+
+final String CHECKSTYLE_CONFIG = """
+<!DOCTYPE module PUBLIC
+  "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+  "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <module name="TreeWalker">
+    <!-- Use CHECKSTYLE:OFF and CHECKSTYLE:ON comments to suppress checkstyle lints in a block -->
+    <module name="SuppressionCommentFilter"/>
+    <module name="AvoidStarImport">
+      <!-- Allow static wildcard imports for cases like Opcodes and LWJGL classes, these don't get created accidentally by the IDE -->
+      <property name="allowStaticMemberImports" value="true"/>
+    </module>
+  </module>
+</module>
+"""
 
 checkPropertyExists("modName")
 checkPropertyExists("modId")
@@ -138,6 +155,17 @@ project.extensions.add(com.diffplug.blowdryer.Blowdryer, "Blowdryer", com.diffpl
 if (!disableSpotless) {
     apply plugin: 'com.diffplug.spotless'
     apply from: Blowdryer.file('spotless.gradle')
+}
+
+if (!disableCheckstyle) {
+    apply plugin: 'checkstyle'
+    tasks.named("checkstylePatchedMc") { enabled = false }
+    tasks.named("checkstyleMcLauncher") { enabled = false }
+    tasks.named("checkstyleIdeVirtualMain") { enabled = false }
+    tasks.named("checkstyleInjectedTags") { enabled = false }
+    checkstyle {
+        config = resources.text.fromString(CHECKSTYLE_CONFIG)
+    }
 }
 
 String javaSourceDir = "src/main/java/"
@@ -562,9 +590,6 @@ repositories {
     maven {
         name 'Overmind forge repo mirror'
         url 'https://gregtech.overminddl1.com/'
-        mavenContent {
-            excludeGroup("net.minecraftforge") // missing the `universal` artefact
-        }
     }
     maven {
         name = "GTNH Maven"
@@ -603,15 +628,10 @@ repositories {
         }
         maven {
             name = "ic2"
-            url = "https://maven.ic2.player.to/"
-            metadataSources {
-                mavenPom()
-                artifact()
+            url = getURL("https://maven.ic2.player.to/", "https://maven2.ic2.player.to/")
+            content {
+                includeGroup "net.industrial-craft"
             }
-        }
-        maven {
-            name = "ic2-mirror"
-            url = "https://maven2.ic2.player.to/"
             metadataSources {
                 mavenPom()
                 artifact()
@@ -773,23 +793,14 @@ ext.java17PatchDependenciesCfg = configurations.create("java17PatchDependencies"
 }
 
 dependencies {
-    def lwjgl3ifyVersion = '1.4.0'
-    def asmVersion = '9.4'
+    def lwjgl3ifyVersion = '1.5.0'
     if (modId != 'lwjgl3ify') {
         java17Dependencies("com.github.GTNewHorizons:lwjgl3ify:${lwjgl3ifyVersion}")
     }
     if (modId != 'hodgepodge') {
-        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.2.26')
+        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.3.5')
     }
 
-    java17PatchDependencies('net.minecraft:launchwrapper:1.17.2') {transitive = false}
-    java17PatchDependencies("org.ow2.asm:asm:${asmVersion}")
-    java17PatchDependencies("org.ow2.asm:asm-commons:${asmVersion}")
-    java17PatchDependencies("org.ow2.asm:asm-tree:${asmVersion}")
-    java17PatchDependencies("org.ow2.asm:asm-analysis:${asmVersion}")
-    java17PatchDependencies("org.ow2.asm:asm-util:${asmVersion}")
-    java17PatchDependencies('org.ow2.asm:asm-deprecated:7.1')
-    java17PatchDependencies("org.apache.commons:commons-lang3:3.12.0")
     java17PatchDependencies("com.github.GTNewHorizons:lwjgl3ify:${lwjgl3ifyVersion}:forgePatches") {transitive = false}
 }
 
@@ -1577,6 +1588,25 @@ def getSecondaryArtifacts() {
     if (!noPublishedSources) secondaryArtifacts += [sourcesJar]
     if (apiPackage) secondaryArtifacts += [apiJar]
     return secondaryArtifacts
+}
+
+def getURL(String main, String fallback) {
+    return pingURL(main, 10000) ? main : fallback
+}
+
+// credit: https://stackoverflow.com/a/3584332
+def pingURL(String url, int timeout) {
+    url = url.replaceFirst("^https", "http") // Otherwise an exception may be thrown on invalid SSL certificates.
+    try {
+        HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection()
+        connection.setConnectTimeout(timeout)
+        connection.setReadTimeout(timeout)
+        connection.setRequestMethod("HEAD")
+        int responseCode = connection.getResponseCode()
+        return 200 <= responseCode && responseCode <= 399
+    } catch (IOException ignored) {
+        return false
+    }
 }
 
 // For easier scripting of things that require variables defined earlier in the buildscript

--- a/src/main/java/binnie/core/craftgui/minecraft/GuiCraftGUI.java
+++ b/src/main/java/binnie/core/craftgui/minecraft/GuiCraftGUI.java
@@ -11,6 +11,7 @@ import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.entity.player.InventoryPlayer;
+import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.JsonToNBT;
 import net.minecraft.nbt.NBTException;
@@ -30,6 +31,8 @@ import binnie.core.craftgui.events.EventMouse;
 import binnie.core.craftgui.geometry.IArea;
 import binnie.core.craftgui.geometry.IBorder;
 import binnie.core.craftgui.geometry.IPoint;
+import binnie.core.craftgui.minecraft.control.ControlSlot;
+import binnie.core.nei.NEIHook;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
@@ -76,6 +79,8 @@ public class GuiCraftGUI extends GuiContainer {
 
     @Override
     public void drawScreen(int mouseX, int mouseY, float par3) {
+        NEIHook.preDraw();
+
         window.setMousePosition(mouseX - (int) window.getPosition().x(), mouseY - (int) window.getPosition().y());
         drawDefaultBackground();
 
@@ -89,6 +94,9 @@ public class GuiCraftGUI extends GuiContainer {
         window.render();
 
         RenderHelper.enableGUIStandardItemLighting();
+
+        NEIHook.renderObjects(window, mouseX, mouseY);
+
         GL11.glPushMatrix();
         GL11.glEnable(32826); // GL_RESCALE_NORMAL_EXT
         OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240.0f, 240.0f);
@@ -110,6 +118,8 @@ public class GuiCraftGUI extends GuiContainer {
             tooltip.setType(Tooltip.Type.STANDARD);
             window.getTooltip(tooltip);
         }
+
+        NEIHook.renderToolTips(mouseX, mouseY);
 
         if (tooltip.exists()) {
             renderTooltip(new IPoint(mouseX, mouseY), tooltip);
@@ -219,15 +229,20 @@ public class GuiCraftGUI extends GuiContainer {
 
     @Override
     protected void mouseClicked(int x, int y, int button) {
+        NEIHook.mouseClicked(x, y, button);
+
         IWidget origin = window;
         if (window.getMousedOverWidget() != null) {
             origin = window.getMousedOverWidget();
         }
         window.callEvent(new EventMouse.Down(origin, x, y, button));
+        NEIHook.mouseUp(x, y, button);
     }
 
     @Override
     protected void keyTyped(char c, int key) {
+        NEIHook.lastKeyTyped(key, c);
+
         if (key == 1 || (key == mc.gameSettings.keyBindInventory.getKeyCode() && window.getFocusedWidget() == null)) {
             mc.thePlayer.closeScreen();
         }
@@ -250,6 +265,8 @@ public class GuiCraftGUI extends GuiContainer {
         if (dWheel != 0) {
             window.callEvent(new EventMouse.Wheel(window, dWheel));
         }
+
+        NEIHook.handleMouseWheel();
     }
 
     @Override
@@ -505,5 +522,14 @@ public class GuiCraftGUI extends GuiContainer {
         GL11.glColor4f(1, 1, 1, 255);
         GL11.glDisable(GL11.GL_BLEND);
         GL11.glEnable(GL11.GL_TEXTURE_2D);
+    }
+
+    public ItemStack getStackUnderMouse(int x, int y) {
+        Slot slot = window.calculateMousedOverWidgets().stream().filter(widget -> widget instanceof ControlSlot).findFirst()
+                .map(w -> ((ControlSlot) w).slot).orElse(null);
+        if (slot == null)
+            return null;
+        else
+            return slot.getStack();
     }
 }

--- a/src/main/java/binnie/core/craftgui/minecraft/GuiCraftGUI.java
+++ b/src/main/java/binnie/core/craftgui/minecraft/GuiCraftGUI.java
@@ -525,11 +525,9 @@ public class GuiCraftGUI extends GuiContainer {
     }
 
     public ItemStack getStackUnderMouse(int x, int y) {
-        Slot slot = window.calculateMousedOverWidgets().stream().filter(widget -> widget instanceof ControlSlot).findFirst()
-                .map(w -> ((ControlSlot) w).slot).orElse(null);
-        if (slot == null)
-            return null;
-        else
-            return slot.getStack();
+        Slot slot = window.calculateMousedOverWidgets().stream().filter(widget -> widget instanceof ControlSlot)
+                .findFirst().map(w -> ((ControlSlot) w).slot).orElse(null);
+        if (slot == null) return null;
+        else return slot.getStack();
     }
 }

--- a/src/main/java/binnie/core/craftgui/minecraft/GuiCraftGUI.java
+++ b/src/main/java/binnie/core/craftgui/minecraft/GuiCraftGUI.java
@@ -255,6 +255,7 @@ public class GuiCraftGUI extends GuiContainer {
         if (button != -1) {
             window.callEvent(new EventMouse.Up(origin, x, y, button));
         }
+        NEIHook.mouseUp(x, y, button);
     }
 
     @Override

--- a/src/main/java/binnie/core/craftgui/minecraft/GuiCraftGUI.java
+++ b/src/main/java/binnie/core/craftgui/minecraft/GuiCraftGUI.java
@@ -236,7 +236,6 @@ public class GuiCraftGUI extends GuiContainer {
             origin = window.getMousedOverWidget();
         }
         window.callEvent(new EventMouse.Down(origin, x, y, button));
-        NEIHook.mouseUp(x, y, button);
     }
 
     @Override

--- a/src/main/java/binnie/core/craftgui/minecraft/GuiCraftGUI.java
+++ b/src/main/java/binnie/core/craftgui/minecraft/GuiCraftGUI.java
@@ -525,9 +525,7 @@ public class GuiCraftGUI extends GuiContainer {
     }
 
     public ItemStack getStackUnderMouse(int x, int y) {
-        Slot slot = window.calculateMousedOverWidgets().stream().filter(widget -> widget instanceof ControlSlot)
-                .findFirst().map(w -> ((ControlSlot) w).slot).orElse(null);
-        if (slot == null) return null;
-        else return slot.getStack();
+        return window.calculateMousedOverWidgets().stream().filter(widget -> widget instanceof ControlSlot).findFirst()
+                .map(w -> ((ControlSlot) w).slot).map(Slot::getStack).orElse(null);
     }
 }

--- a/src/main/java/binnie/core/nei/ContainerObjectHandler.java
+++ b/src/main/java/binnie/core/nei/ContainerObjectHandler.java
@@ -1,0 +1,44 @@
+package binnie.core.nei;
+
+import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.item.ItemStack;
+
+import binnie.core.craftgui.minecraft.GuiCraftGUI;
+import codechicken.nei.guihook.IContainerObjectHandler;
+
+public final class ContainerObjectHandler implements IContainerObjectHandler {
+
+    @Override
+    public void guiTick(GuiContainer gui) {
+
+    }
+
+    @Override
+    public void refresh(GuiContainer gui) {
+
+    }
+
+    @Override
+    public void load(GuiContainer gui) {
+
+    }
+
+    @Override
+    public ItemStack getStackUnderMouse(GuiContainer gui, int mousex, int mousey) {
+        if (gui instanceof GuiCraftGUI) {
+            return ((GuiCraftGUI) gui).getStackUnderMouse(mousex, mousey);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public boolean objectUnderMouse(GuiContainer gui, int mousex, int mousey) {
+        return false;
+    }
+
+    @Override
+    public boolean shouldShowTooltip(GuiContainer gui) {
+        return true;
+    }
+}

--- a/src/main/java/binnie/core/nei/ContainerObjectHandler.java
+++ b/src/main/java/binnie/core/nei/ContainerObjectHandler.java
@@ -5,7 +5,12 @@ import net.minecraft.item.ItemStack;
 
 import binnie.core.craftgui.minecraft.GuiCraftGUI;
 import codechicken.nei.guihook.IContainerObjectHandler;
+import cpw.mods.fml.common.Optional;
 
+@Optional.Interface(
+        iface = "codechicken.nei.guihook.IContainerObjectHandler",
+        modid = "NotEnoughItems",
+        striprefs = true)
 public final class ContainerObjectHandler implements IContainerObjectHandler {
 
     @Override

--- a/src/main/java/binnie/core/nei/NEIHook.java
+++ b/src/main/java/binnie/core/nei/NEIHook.java
@@ -4,55 +4,97 @@ import org.lwjgl.opengl.GL11;
 
 import binnie.core.craftgui.minecraft.Window;
 import codechicken.nei.guihook.GuiContainerManager;
+import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.Optional;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 
+@SideOnly(Side.CLIENT)
 public final class NEIHook {
 
-    private static boolean enabled = false;
+    public static boolean enabled = false;
 
     static {
-        try {
-            GuiContainerManager.addObjectHandler(new ContainerObjectHandler());
+        if (Loader.isModLoaded("NotEnoughItems")) {
             enabled = true;
-        } catch (NoClassDefFoundError ignored) {
-
+            addHandler();
         }
     }
 
+    @Optional.Method(modid = "NotEnoughItems")
+    private static void addHandler() {
+        GuiContainerManager.addObjectHandler(new ContainerObjectHandler());
+    }
+
+    @Optional.Method(modid = "NotEnoughItems")
     private static GuiContainerManager getManager() {
         return GuiContainerManager.getManager();
     }
 
+    @Optional.Method(modid = "NotEnoughItems")
+    private static void preDrawImpl() {
+        getManager().preDraw();
+    }
+
     public static void preDraw() {
-        if (enabled) getManager().preDraw();
+        if (enabled) preDrawImpl();
+    }
+
+    @Optional.Method(modid = "NotEnoughItems")
+    private static void renderObjectsImpl(Window window, int mouseX, int mouseY) {
+        GL11.glPushMatrix();
+        GL11.glTranslatef(window.x(), window.y(), 0.0f);
+        GuiContainerManager.getManager().renderObjects(mouseX, mouseY);
+        GL11.glTranslatef(-window.x(), -window.y(), 0.0f);
+        GL11.glPopMatrix();
     }
 
     public static void renderObjects(Window window, int mouseX, int mouseY) {
-        if (enabled) {
-            GL11.glPushMatrix();
-            GL11.glTranslatef(window.x(), window.y(), 0.0f);
-            GuiContainerManager.getManager().renderObjects(mouseX, mouseY);
-            GL11.glTranslatef(-window.x(), -window.y(), 0.0f);
-            GL11.glPopMatrix();
-        }
+        if (enabled) renderObjectsImpl(window, mouseX, mouseY);
+    }
+
+    @Optional.Method(modid = "NotEnoughItems")
+    private static void renderToolTipsImpl(int mouseX, int mouseY) {
+        getManager().renderToolTips(mouseX, mouseY);
     }
 
     public static void renderToolTips(int mouseX, int mouseY) {
-        if (enabled) getManager().renderToolTips(mouseX, mouseY);
+        if (enabled) renderToolTipsImpl(mouseX, mouseY);
+    }
+
+    @Optional.Method(modid = "NotEnoughItems")
+    private static void mouseClickedImpl(int x, int y, int button) {
+        getManager().mouseClicked(x, y, button);
     }
 
     public static void mouseClicked(int x, int y, int button) {
-        if (enabled) getManager().mouseClicked(x, y, button);
+        if (enabled) mouseClickedImpl(x, y, button);
+    }
+
+    @Optional.Method(modid = "NotEnoughItems")
+    private static void lastKeyTypedImpl(int k, char c) {
+        getManager().lastKeyTyped(k, c);
     }
 
     public static void lastKeyTyped(int k, char c) {
-        if (enabled) getManager().lastKeyTyped(k, c);
+        if (enabled) lastKeyTypedImpl(k, c);
+    }
+
+    @Optional.Method(modid = "NotEnoughItems")
+    private static void handleMouseWheelImpl() {
+        getManager().handleMouseWheel();
     }
 
     public static void handleMouseWheel() {
-        if (enabled) getManager().handleMouseWheel();
+        if (enabled) handleMouseWheelImpl();
+    }
+
+    @Optional.Method(modid = "NotEnoughItems")
+    private static void mouseUpImpl(int mouseX, int mouseY, int button) {
+        getManager().mouseUp(mouseX, mouseY, button);
     }
 
     public static void mouseUp(int mouseX, int mouseY, int button) {
-        if (enabled) getManager().mouseUp(mouseX, mouseY, button);
+        if (enabled) mouseUpImpl(mouseX, mouseY, button);
     }
 }

--- a/src/main/java/binnie/core/nei/NEIHook.java
+++ b/src/main/java/binnie/core/nei/NEIHook.java
@@ -1,0 +1,58 @@
+package binnie.core.nei;
+
+import org.lwjgl.opengl.GL11;
+
+import binnie.core.craftgui.minecraft.Window;
+import codechicken.nei.guihook.GuiContainerManager;
+
+public final class NEIHook {
+
+    private static boolean enabled = false;
+
+    static {
+        try {
+            GuiContainerManager.addObjectHandler(new ContainerObjectHandler());
+            enabled = true;
+        } catch (NoClassDefFoundError ignored) {
+
+        }
+    }
+
+    private static GuiContainerManager getManager() {
+        return GuiContainerManager.getManager();
+    }
+
+    public static void preDraw() {
+        if (enabled) getManager().preDraw();
+    }
+
+    public static void renderObjects(Window window, int mouseX, int mouseY) {
+        if (enabled) {
+            GL11.glPushMatrix();
+            GL11.glTranslatef(window.x(), window.y(), 0.0f);
+            GuiContainerManager.getManager().renderObjects(mouseX, mouseY);
+            GL11.glTranslatef(-window.x(), -window.y(), 0.0f);
+            GL11.glPopMatrix();
+        }
+    }
+
+    public static void renderToolTips(int mouseX, int mouseY) {
+        if (enabled) getManager().renderToolTips(mouseX, mouseY);
+    }
+
+    public static void mouseClicked(int x, int y, int button) {
+        if (enabled) getManager().mouseClicked(x, y, button);
+    }
+
+    public static void lastKeyTyped(int k, char c) {
+        if (enabled) getManager().lastKeyTyped(k, c);
+    }
+
+    public static void handleMouseWheel() {
+        if (enabled) getManager().handleMouseWheel();
+    }
+
+    public static void mouseUp(int mouseX, int mouseY, int button) {
+        if (enabled) getManager().mouseUp(mouseX, mouseY, button);
+    }
+}

--- a/src/main/java/binnie/core/nei/NEIHook.java
+++ b/src/main/java/binnie/core/nei/NEIHook.java
@@ -33,7 +33,8 @@ public final class NEIHook {
 
     @Optional.Method(modid = "NotEnoughItems")
     private static void preDrawImpl() {
-        getManager().preDraw();
+        GuiContainerManager manager = getManager();
+        if (manager != null) manager.preDraw();
     }
 
     public static void preDraw() {
@@ -44,7 +45,8 @@ public final class NEIHook {
     private static void renderObjectsImpl(Window window, int mouseX, int mouseY) {
         GL11.glPushMatrix();
         GL11.glTranslatef(window.x(), window.y(), 0.0f);
-        GuiContainerManager.getManager().renderObjects(mouseX, mouseY);
+        GuiContainerManager manager = getManager();
+        if (manager != null) manager.renderObjects(mouseX, mouseY);
         GL11.glTranslatef(-window.x(), -window.y(), 0.0f);
         GL11.glPopMatrix();
     }
@@ -55,7 +57,8 @@ public final class NEIHook {
 
     @Optional.Method(modid = "NotEnoughItems")
     private static void renderToolTipsImpl(int mouseX, int mouseY) {
-        getManager().renderToolTips(mouseX, mouseY);
+        GuiContainerManager manager = getManager();
+        if (manager != null) manager.renderToolTips(mouseX, mouseY);
     }
 
     public static void renderToolTips(int mouseX, int mouseY) {
@@ -64,7 +67,8 @@ public final class NEIHook {
 
     @Optional.Method(modid = "NotEnoughItems")
     private static void mouseClickedImpl(int x, int y, int button) {
-        getManager().mouseClicked(x, y, button);
+        GuiContainerManager manager = getManager();
+        if (manager != null) manager.mouseClicked(x, y, button);
     }
 
     public static void mouseClicked(int x, int y, int button) {
@@ -73,7 +77,8 @@ public final class NEIHook {
 
     @Optional.Method(modid = "NotEnoughItems")
     private static void lastKeyTypedImpl(int k, char c) {
-        getManager().lastKeyTyped(k, c);
+        GuiContainerManager manager = getManager();
+        if (manager != null) manager.lastKeyTyped(k, c);
     }
 
     public static void lastKeyTyped(int k, char c) {
@@ -82,7 +87,8 @@ public final class NEIHook {
 
     @Optional.Method(modid = "NotEnoughItems")
     private static void handleMouseWheelImpl() {
-        getManager().handleMouseWheel();
+        GuiContainerManager manager = getManager();
+        if (manager != null) manager.handleMouseWheel();
     }
 
     public static void handleMouseWheel() {
@@ -91,7 +97,8 @@ public final class NEIHook {
 
     @Optional.Method(modid = "NotEnoughItems")
     private static void mouseUpImpl(int mouseX, int mouseY, int button) {
-        getManager().mouseUp(mouseX, mouseY, button);
+        GuiContainerManager manager = getManager();
+        if (manager != null) manager.mouseUp(mouseX, mouseY, button);
     }
 
     public static void mouseUp(int mouseX, int mouseY, int button) {

--- a/src/main/java/binnie/core/nei/NEIUtils.java
+++ b/src/main/java/binnie/core/nei/NEIUtils.java
@@ -2,7 +2,11 @@ package binnie.core.nei;
 
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
-import net.minecraftforge.fluids.*;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidContainerRegistry;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.IFluidBlock;
+import net.minecraftforge.fluids.IFluidContainerItem;
 
 public class NEIUtils {
 

--- a/src/main/java/binnie/core/nei/PositionedFluidTank.java
+++ b/src/main/java/binnie/core/nei/PositionedFluidTank.java
@@ -1,6 +1,7 @@
 package binnie.core.nei;
 
-import java.awt.*;
+import java.awt.Point;
+import java.awt.Rectangle;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;

--- a/src/main/java/binnie/core/nei/PositionedStackAdv.java
+++ b/src/main/java/binnie/core/nei/PositionedStackAdv.java
@@ -1,6 +1,6 @@
 package binnie.core.nei;
 
-import java.awt.*;
+import java.awt.Rectangle;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/binnie/core/nei/RecipeHandlerBase.java
+++ b/src/main/java/binnie/core/nei/RecipeHandlerBase.java
@@ -1,6 +1,7 @@
 package binnie.core.nei;
 
-import java.awt.*;
+import java.awt.Point;
+import java.awt.Rectangle;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/binnie/extrabees/genetics/ExtraBeeMutation.java
+++ b/src/main/java/binnie/extrabees/genetics/ExtraBeeMutation.java
@@ -4,7 +4,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import binnie.extrabees.genetics.requirements.*;
+import binnie.extrabees.genetics.requirements.DummyMutationCondition;
+import binnie.extrabees.genetics.requirements.IMutationRequirement;
+import binnie.extrabees.genetics.requirements.RequirementPerson;
 import forestry.api.apiculture.BeeManager;
 import forestry.api.apiculture.IAlleleBeeSpecies;
 import forestry.api.apiculture.IBeeGenome;

--- a/src/main/java/binnie/extratrees/nei/NEIHandlerLumbermill.java
+++ b/src/main/java/binnie/extratrees/nei/NEIHandlerLumbermill.java
@@ -1,6 +1,6 @@
 package binnie.extratrees.nei;
 
-import java.awt.*;
+import java.awt.Rectangle;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/binnie/genetics/nei/GenepoolRecipeHandler.java
+++ b/src/main/java/binnie/genetics/nei/GenepoolRecipeHandler.java
@@ -1,6 +1,6 @@
 package binnie.genetics.nei;
 
-import java.awt.*;
+import java.awt.Rectangle;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/binnie/genetics/nei/IncubatorRecipeHandler.java
+++ b/src/main/java/binnie/genetics/nei/IncubatorRecipeHandler.java
@@ -1,6 +1,6 @@
 package binnie.genetics.nei;
 
-import java.awt.*;
+import java.awt.Rectangle;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/binnie/genetics/nei/InoculatorRecipeHandler.java
+++ b/src/main/java/binnie/genetics/nei/InoculatorRecipeHandler.java
@@ -1,6 +1,6 @@
 package binnie.genetics.nei;
 
-import java.awt.*;
+import java.awt.Rectangle;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/binnie/genetics/nei/IsolatorRecipeHandler.java
+++ b/src/main/java/binnie/genetics/nei/IsolatorRecipeHandler.java
@@ -1,6 +1,6 @@
 package binnie.genetics.nei;
 
-import java.awt.*;
+import java.awt.Rectangle;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/binnie/genetics/nei/PolymeriserRecipeHandler.java
+++ b/src/main/java/binnie/genetics/nei/PolymeriserRecipeHandler.java
@@ -1,6 +1,6 @@
 package binnie.genetics.nei;
 
-import java.awt.*;
+import java.awt.Rectangle;
 import java.util.ArrayList;
 import java.util.List;
 


### PR DESCRIPTION
Previously, the NEI asm did not work as `GuiCraftGUI` override some methods and treat Slots specially as storage logic only,
 so I do Hooks manually and add a `IContainerObjectHandler ` to handle the slot under mouse.

Other fixes might be 
1. mixin, but it’s bad mixining everywhere
2. refactor NEI for more general treatments, which is no better than mixin as it’s based on asm.

<img width="2056" alt="截屏2023-09-25 21 40 22" src="https://github.com/GTNewHorizons/Binnie/assets/57822596/018602f1-b7ab-479a-a15d-0347e7905c4e">
