### PR TITLE
Optimized flower color enumeration array retrieval

### DIFF
--- a/src/main/java/binnie/botany/genetics/EnumFlowerColor.java
+++ b/src/main/java/binnie/botany/genetics/EnumFlowerColor.java
@@ -92,6 +92,7 @@ public enum EnumFlowerColor implements IFlowerColor {
     YELLOW("yellow", 0xffff00),
     YELLOW_GREEN("yellowGreen", 0x9acd32);
 
+    private static final EnumFlowerColor[] ALL_VALUES = values();
     private int color;
     private int colorDis;
     private String name;
@@ -2963,7 +2964,7 @@ public enum EnumFlowerColor implements IFlowerColor {
     }
 
     public static EnumFlowerColor get(int i) {
-        return values()[Math.max(0, i) % values().length];
+        return ALL_VALUES[Math.max(0, i) % ALL_VALUES.length];
     }
 
     @Override


### PR DESCRIPTION
Due to the copy of the enum values that `values()` does this was allocating around 600MB/s when viewing all Binnie bricks in NEI. This has been replaced with a static constant that only fetches the enum values once. Attached is a video of the allocation speed.
https://github.com/GTNewHorizons/Binnie/assets/45769595/9302a40d-2c23-43f4-8579-875aadcb7351

