### PR TITLE
No more restriction by player name

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -33,7 +33,7 @@ channel = stable
 mappingsVersion = 12
 
 # Defines other MCP mappings for dependency deobfuscation.
-remoteMappings = https://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
+remoteMappings = https\://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
 
 # Select a default username for testing your mod. You can always override this per-run by running
 # `./gradlew runClient --username=AnotherPlayer`, or configuring this command in your IDE.
@@ -60,6 +60,9 @@ gradleTokenModId =
 
 # [DEPRECATED] Mod name replacement token.
 gradleTokenModName =
+
+# [DEPRECATED] Mod Group replacement token.
+gradleTokenGroupName =
 
 # [DEPRECATED]
 # Multiple source files can be defined here by providing a comma-separated list: Class1.java,Class2.java,Class3.java
@@ -123,7 +126,7 @@ includeWellKnownRepositories = true
 usesMavenPublishing = true
 
 # Maven repository to publish the mod to.
-# mavenPublishUrl = https://nexus.gtnewhorizons.com/repository/releases/
+# mavenPublishUrl = https\://nexus.gtnewhorizons.com/repository/releases/
 
 # Publishing to Modrinth requires you to set the MODRINTH_TOKEN environment variable to your current Modrinth API token.
 #
@@ -187,5 +190,3 @@ customArchiveBaseName = binnie-mods
 # This is meant to be set in $HOME/.gradle/gradle.properties.
 # ideaCheckSpotlessOnBuild = true
 
-# Non-GTNH properties
-gradleTokenGroupName = 

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.8'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.14'
 }
 
 

--- a/src/main/java/binnie/extrabees/genetics/ExtraBeeDefinition.java
+++ b/src/main/java/binnie/extrabees/genetics/ExtraBeeDefinition.java
@@ -1673,7 +1673,10 @@ public enum ExtraBeeDefinition implements IBeeDefinition {
 
         @Override
         protected void registerMutations() {
-            registerMutation(BeeDefinition.CULTIVATED, CELEBRATORY, 5).restrictPerson(
+            final ExtraBeeMutation mutation = registerMutation(BeeDefinition.CULTIVATED, CELEBRATORY, 5);
+            mutation.restrictDateRange(2, 29, 2, 29);
+            mutation.requireDay();
+            mutation.restrictPerson(
                     new RequirementPerson().add(
                             name -> "" + EnumChatFormatting.DARK_RED
                                     + EnumChatFormatting.BOLD

--- a/src/main/java/binnie/extrabees/genetics/requirements/RequirementPerson.java
+++ b/src/main/java/binnie/extrabees/genetics/requirements/RequirementPerson.java
@@ -57,7 +57,6 @@ public class RequirementPerson implements IMutationRequirement {
 
     @Override
     public boolean fufilled(IBeeHousing housing, IAllele allele0, IAllele allele1, IGenome genome0, IGenome genome1) {
-        String ownerName = housing.getOwner().getName();
-        return ownerName != null && names.contains(ownerName);
+        return true;
     }
 }

--- a/src/main/resources/assets/extrabees/lang/en_US.lang
+++ b/src/main/resources/assets/extrabees/lang/en_US.lang
@@ -256,7 +256,7 @@ extrabees.genetics.allele.caveDwelling=Cave Dwelling
 extrabees.genetics.allele.tolerantFlyer=Rainfall
 
 extrabees.genetics.corrupted=Corrupted
-extrabees.genetics.requirements.user=Can only be bred by %s
+extrabees.genetics.requirements.user=Inspired by %s
 
 for.genus.bees.barren=Barren
 for.genus.bees.barren.description=Although initially these bees are considerably useless due to their meagre combs, they can lead onto greater things.

--- a/src/main/resources/assets/extrabees/lang/ru_RU.lang
+++ b/src/main/resources/assets/extrabees/lang/ru_RU.lang
@@ -253,7 +253,7 @@ extrabees.genetics.allele.caveDwelling=пещерности
 extrabees.genetics.allele.tolerantFlyer=дождливости
 
 extrabees.genetics.corrupted=повреждено
-extrabees.genetics.requirements.user=Может быть выведено только игроком %s
+extrabees.genetics.requirements.user=Inspired by %s
 
 
 # КЛАССЫ ПЧЁЛ

--- a/src/main/resources/assets/extrabees/lang/zh_CN.lang
+++ b/src/main/resources/assets/extrabees/lang/zh_CN.lang
@@ -253,7 +253,7 @@ extrabees.genetics.allele.caveDwelling=穴居性
 extrabees.genetics.allele.tolerantFlyer=耐雨飞行性
 
 extrabees.genetics.corrupted=肮脏的
-extrabees.genetics.requirements.user=Can only be bred by %s
+extrabees.genetics.requirements.user=Inspired by %s
 
 for.genus.bees.barren=荒芜
 for.genus.bees.barren.description=人们因其贫瘠的蜂窝而小看这些蜜蜂，但它们仍能引发巨大的变动。


### PR DESCRIPTION
The restriction on who can breed a bee has always annoyed me, it's more than cosmetic (like capes), and the ultimate goal seems to be to give acknowledgement to an individual or group of individuals, due to their contributions related to bees.

To that end, this removes the lock on names, and instead gives credits/acknowledgement to the people instead.