### PR TITLE
Add Localization, Fix Carpentry Hammer / Master Carpentry Hammer Names being reverse

### DIFF
--- a/src/main/resources/assets/binniecore/lang/en_US.lang
+++ b/src/main/resources/assets/binniecore/lang/en_US.lang
@@ -196,11 +196,17 @@ binniecore.gui.breedingmessage.epithet=Epithet Gained
 binniecore.item.genesis.name=Genesis
 binniecore.item.fluidContainer.missed=Missed Fluid
 
+item.containerCapsule.name=Capsule
 binniecore.item.container.capsule=Capsule
+item.containerRefractory.name=Capsule
 binniecore.item.container.refractory=Capsule
+item.containerCan.name=Can
 binniecore.item.container.can=Can
+item.containerBucket.name=Bucket
 binniecore.item.container.bucket=Bucket
+item.containerGlass.name=Bottle
 binniecore.item.container.glass=Bottle
+item.containerCylinder.name=Cylinder
 binniecore.item.container.cylinder=Cylinder
 
 binniecore.item.container.capsule.acid=Acid Capsule
@@ -291,6 +297,7 @@ binniecore.machine.storage.filterBlocks=Include Blocks
 < %1$s is the name of the pattern >
 binniecore.gui.designer.pattern=%1$s Pattern
 
+item.fieldKit.name=Field Kit
 binniecore.gui.fieldKit=Field Kit
 binniecore.gui.fieldKit.info=The Field Kit analyses bees, trees, flowers and butterflies. All that is required is a piece of paper to jot notes
 
@@ -456,3 +463,6 @@ binniecore.gui.side.west=West
 binniecore.gui.side.south=South
 binniecore.gui.side.insertSide=Insert Side: %s
 binniecore.gui.side.extractSide=Extract Side: %s
+
+item.genesis.name=Genesis
+tile.storage.name=Compartment

--- a/src/main/resources/assets/botany/lang/en_US.lang
+++ b/src/main/resources/assets/botany/lang/en_US.lang
@@ -1,9 +1,13 @@
 botany.tab.botany=Botany
 
+tile.stained.name=Pigmented Glass
 botany.pigmentedGlass=Pigmented Glass
+tile.ceramic.name=Ceramic Block
 botany.ceramicBlock=Ceramic Block
+tile.ceramicBrick.name=Ceramic Tile
 botany.ceramicTile=Ceramic Tile
 botany.ceramicBricks=Ceramic Bricks
+tile.ceramicPattern.name=Ceramic Block
 botany.strippedCeramicBricks=Striped Ceramic Bricks
 botany.largeCeramicBricks=Large Ceramic Bricks
 botany.splitCeramicTile=Split Ceramic Tile
@@ -130,14 +134,21 @@ botany.moisture.dry=Dry
 botany.moisture.normal=Normal
 botany.moisture.damp=Damp
 
+tile.plant.name=Plant
 botany.plant.weeds=Weeds
 botany.plant.longWeeds=Long Weeds
 botany.plant.veryLongWeeds=Very Long Weeds
 botany.plant.deadFlower=Dead Flower
 botany.plant.decayingFlower=Decaying Flower
 
+tile.soil.name=Soil
+tile.soilNoWeed.name=Soil
 botany.soil.soil=Soil
+tile.loam.name=Loam
+tile.loamNoWeed.name=Loam
 botany.soil.loam=Loam
+tile.flowerbed.name=Flowerbed
+tile.flowerbedNoWeed.name=Flowerbed
 botany.soil.flowerbed=Flowerbed
 botany.soil.weedkiller=Weedkiller
 
@@ -158,15 +169,20 @@ botany.item.tooltip.fertility=Fertility: %dx
 botany.item.tooltip.flowerColor1=%1$s, %2$s Stem
 botany.item.tooltip.flowerColor2=%1$s and %2$s, %3$s Stem
 
+item.soilMeter.name=Soil Meter
 botany.item.soilMeter.name=Soil Meter
+item.pigment.name=Pigment
 botany.item.pigment.name=Pigment
 botany.item.clay.name=Clay
 botany.item.botany.name=%1$s %2$s
+item.pollen.name=Pollen
 botany.item.pollen.tag.name=Pollen
 botany.item.germling.tag.name=Germling
 botany.item.flowerCorrupted.name=Corrupted Flower
+item.database.name=Botanist Database
 botany.item.database.0.name=Botanist Database
 botany.item.database.1.name=Master Botanist Database
+item.misc.name=Powder
 botany.item.powderAsh.name=Ash Powder
 botany.item.powderPulp.name=Pulp Powder
 botany.item.powderMulch.name=Mulch Powder
@@ -182,6 +198,7 @@ item.trowelIron.name=Iron Trowel
 item.trowelGold.name=Gold Trowel
 item.trowelDiamond.name=Diamond Trowel
 
+item.itemFlower.name=Flower
 botany.flower.name=Flower
 botany.flower.dandelion=Dandelion
 botany.flower.poppy=Poppy
@@ -365,6 +382,7 @@ for.binnie.circuit.garden.damp.acid=Garden (Damp, Acidic)
 for.binnie.circuit.garden.damp.neutral=Garden (Damp, Neutral)
 for.binnie.circuit.garden.damp.alkaline=Garden (Damp, Alkaline)
 
+item.insulatedTube.name=Insulated Tube
 botany.tube.name=Insulated Tube
 botany.tube.copper=Copper
 botany.tube.tin=Tin
@@ -456,3 +474,5 @@ botany.gui.database.tab.breeder=Breeder
 
 botany.gui.database.tab.colour.resultant=Resultant Mixes
 botany.gui.database.tab.colour.further=Further Mixes
+
+item.seed.name=Seed

--- a/src/main/resources/assets/extrabees/lang/en_US.lang
+++ b/src/main/resources/assets/extrabees/lang/en_US.lang
@@ -1,6 +1,7 @@
 ##################################################
 ## Items
 
+item.honeyComb.name=Comb
 extrabees.item.comb.barren=Barren Comb
 extrabees.item.comb.rotten=Rotten Comb
 extrabees.item.comb.bone=Bone Comb
@@ -74,6 +75,7 @@ extrabees.item.comb.yellorium=Yellorium Comb
 extrabees.item.comb.cyanite=Cyanite Comb
 extrabees.item.comb.blutonium=Blutonium Comb
 
+item.honeyDrop.name=Drop
 extrabees.item.honeydrop.energy=Energy Drop
 extrabees.item.honeydrop.acid=Acidic Drop
 extrabees.item.honeydrop.poison=Venomous Drop
@@ -104,12 +106,14 @@ extrabees.item.honeydrop.limegreen=Lime Green Tinted Honey
 extrabees.item.honeydrop.magenta=Magenta Tinted Honey
 extrabees.item.honeydrop.lightgray=Light Gray Tinted Honey
 
+item.propolis.name=Propolis
 extrabees.item.propolis.water=Watery Propolis
 extrabees.item.propolis.oil=Oily Propolis
 extrabees.item.propolis.fuel=Petroleum Propolis
 extrabees.item.propolis.creosote=Creosote Propolis
 extrabees.item.propolis.peat=Peat Propolis
 
+item.hiveFrame.name=Hive Frame
 extrabees.item.frame.cocoa=Chocolate Frame
 extrabees.item.frame.cage=Restraint Frame
 extrabees.item.frame.soul=Soul Frame
@@ -127,10 +131,12 @@ extrabees.item.template.corrupted=Corrupted Template
 extrabees.item.template.name=%s Template
 extrabees.item.template.empty=Blank Template
 
+item.dictionary.name=Apiarist Database
 extrabees.item.database=Apiarist Database
 extrabees.item.masterDatabase=Master Apiarist Database
 extrabees.item.database.tooltip=Flora-in-a-box
 
+item.misc.name=Resource
 extrabees.item.scentedGear=Scented Gear
 extrabees.item.diamondShard=Diamond Fragment
 extrabees.item.emeraldShard=Emerald Fragment
@@ -167,6 +173,7 @@ extrabees.block.geneticMachine.name=Genetic Machine
 extrabees.block.advGeneticMachine.name=Advanced Genetic Machine
 extrabees.block.ectoplasm.name=Ectoplasm
 
+tile.hive.name=Hive
 extrabees.block.hive.0=Water Hive
 extrabees.block.hive.1=Rock Hive
 extrabees.block.hive.2=Nether Hive
@@ -194,6 +201,7 @@ extrabees.machine.alveay.lighting.info=The Alveary Lighting tricks bees into thi
 extrabees.machine.alveay.unlighting=Alveary Unlighting
 extrabees.machine.alveay.unlighting.info=The Alveary Unlighting tricks bees into thinking it is night time during the day.
 
+tile.alveary.name=Mutator
 extrabees.machine.alveay.mutator=Mutator
 extrabees.machine.alveay.mutator.info=The Mutator uses certain items in order to encourage bee mutation.
 extrabees.machine.alveay.mutator.tooltip=Mutagenic Agents

--- a/src/main/resources/assets/extratrees/lang/en_US.lang
+++ b/src/main/resources/assets/extratrees/lang/en_US.lang
@@ -1,6 +1,8 @@
 ##################################################
 ## Machines
 
+tile.machine.name=Machine
+
 extratrees.machine.kitchen.bar=Bar
 extratrees.machine.kitchen.bottleRack=Bottle Rack
 
@@ -159,6 +161,7 @@ extratrees.block.tooltip.twoMaterials=%s and %s
 extratrees.block.door.name=%1$s Wood Door
 
 < %1$s is name of wood used for door, %2$s is type of door >
+tile.door.name=Wood Door
 extratrees.block.door.name.adv=%2$s %1$s Wood Door
 extratrees.block.door.type.standard=
 extratrees.block.door.type.solid=Solid
@@ -166,19 +169,24 @@ extratrees.block.door.type.double=Split
 extratrees.block.door.type.full=Full
 
 < %1$s is name of the wood>
+tile.planks.name=Wood Planks
 extratrees.block.plank.name=%1$s Wood Planks
 extratrees.block.log.name=%1$s Wood
+tile.slabs.name=Wood Slab
 extratrees.block.woodslab.name=%1$s Wood Slab
+tile.stairs.name=Stairs
 extratrees.block.woodstairs.name=%1$s Stairs
 extratrees.block.woodfence.name=%1$s Fence
 extratrees.block.woodgate.name=%1$s Gate
 
 < %1$s is the adjective for the fence type, %2$s is the name of the wood >
+tile.multifence.name=Fence
 extratrees.block.multifence.name=%2$s %1$s Gate
 < %3$s is the name of the second wood >
 extratrees.block.multifence.name2=%2$s %1$s & $3$s Gate
 
 < %1$s is name of the design >
+tile.carpentry.name=Wooden Panel/Tile
 extratrees.block.woodentile.name=%1$s Wooden Tile
 extratrees.block.woodenpanel.name=%1$s Wooden Panel
 extratrees.block.stainedglass.name=%1$s Stained Glass
@@ -312,14 +320,18 @@ extratrees.genetics.unknown=<Unknown>
 extratrees.genetics.discoveredBy=Discovered by %s 
 extratrees.genetics.complexity=Complexity: %d 
 
-extratrees.item.carpentryHammer=Master Carpentry Hammer
-extratrees.item.masterCarpentryHammer=Carpentry Hammer
+item.hammer.name=Carpentry Hammer
+extratrees.item.carpentryHammer=Carpentry Hammer
+item.durableHammer.name=Master Carpentry Hammer
+extratrees.item.masterCarpentryHammer=Master Carpentry Hammer
+item.misc.name=Resource
 extratrees.item.sawdust=Sawdust
 extratrees.item.bark=Bark
 extratrees.item.provenGear=Proven Gear
 extratrees.item.woodWax=Wood Polish
 extratrees.item.glassFitting=Glass Fittings
 
+item.food.name=Fruit
 for.extratrees.item.food.apple=Apple
 for.extratrees.item.food.crabapple=Crabapple
 for.extratrees.item.food.orange=Orange
@@ -383,10 +395,12 @@ for.extratrees.item.food.mango=Mango
 for.extratrees.item.food.starfruit=Starfruit
 for.extratrees.item.food.candlenut=Candlenut
 
+item.database.name=Arborist Database
 extratrees.item.database=Arborist Database
 extratrees.item.masterDatabase=Master Arborist Database
 extratrees.item.database.tooltip=Sengir-in-a-can
 
+item.databaseMoth.name=Lepidopterist Database
 extratrees.item.mothDatabase=Lepidopterist Database
 extratrees.item.mothMasterDatabase=Master Lepidopterist Database
 extratrees.item.mothDatabase.tooltip=Binnie's Emporium of Lepidopterans

--- a/src/main/resources/assets/genetics/lang/en_US.lang
+++ b/src/main/resources/assets/genetics/lang/en_US.lang
@@ -9,22 +9,29 @@ genetics.item.fieldKit.tooltip.noPaper=No paper
 genetics.item.fieldKit.tooltip.sheetsOfPaper=%d sheets of paper
 genetics.item.fieldKit.tooltip.sheetOfPaper=%d sheet of paper
 
+item.misc.name=Resource
 genetics.item.casingIron.name=Reinforced Casing
 genetics.item.dnaDye.name=DNA Dye
 genetics.item.dyeFluor.name=Fluorescent Dye
 genetics.item.enzyme.name=Enzyme
 genetics.item.growthMedium.name=Growth Medium
 genetics.item.sequencerEmpty.name=Blank Sequence
+item.serum.name=Empty Serum Vial
 genetics.item.serumEmpty.name=Empty Serum Vial
+item.serumArray.name=Empty Serum Array
 genetics.item.genomeEmpty.name=Empty Serum Array
 genetics.item.cylinderEmpty.name=Glass Cylinder
 genetics.item.integratedCircuit.name=Integrated Circuit Board
 genetics.item.integratedCPU.name=Integrated CPU
 genetics.item.casingCircuit.name=Integrated Casing
+item.analyst.name=Analyst
 genetics.item.analyst.name=Analyst
+item.database.name=Gene Database
 genetics.item.database.0.name=Gene Database
 genetics.item.database.1.name=Master Gene Database
+item.registry.name=Registry
 genetics.item.registry.0.name=Registry
+item.masterRegistry.name=Registry
 genetics.item.registry.1.name=Master Registry
 genetics.item.serum.name=%s Serum
 genetics.item.serumArray.name=%s Serum Array
@@ -42,6 +49,7 @@ genetics.gene.charge.one=1 Charge
 genetics.gene.charge.many=%d Charges
 genetics.gene.more=%d more genes. Hold shift to display
 
+item.sequence.name=DNA Sequence
 genetics.sequence.corrupted=Corrupted Sequence
 genetics.sequence.descriptor=%s DNA Sequence
 genetics.sequence.unknown=<Unknown>
@@ -49,6 +57,7 @@ genetics.sequence.unsequenced=Unsequenced
 genetics.sequence.fully=Fully Sequenced
 genetics.sequence.partially=Partially Sequenced (%d%%)
 
+tile.machine.name=Isolator
 genetics.machine.machine.isolator=Isolator
 genetics.machine.machine.isolator.info=The Isolator takes a random allele from a bee, tree or other individual and copies it into an empty sequence vial. This requires the use of ethanol as a solvent and an enzyme to cut up the DNA. The unsequenced serums can then be amplified in a Polymeriser and sequenced in a Sequencer. This process has a small chance to destroy the individual.
 genetics.machine.isolator.error.noIndividual=No individual to isolate
@@ -102,6 +111,7 @@ genetics.machine.genepool.error.noRoom=Not enough room in Tank
 genetics.machine.genepool.error.noEthanol=Not enough Ethanol
 genetics.machine.genepool.error.insufficientEnzyme=Insufficient Enzyme
 
+tile.labMachine.name=Lab Stand
 genetics.machine.labMachine.labMachine=Lab Stand
 
 genetics.machine.labMachine.analyser=Analyzer
@@ -128,6 +138,7 @@ genetics.machine.acclimatiser.error.noIndividual=No Individual to Acclimatise
 genetics.machine.acclimatiser.error.noAcclimatizingItems=No Acclimatising Items
 genetics.machine.acclimatiser.error.invalidAcclimatizingItems=Cannot Acclimatise this individual with these items
 
+tile.advMachine.name=Splicer
 genetics.machine.advMachine.splicer=Splicer
 genetics.machine.advMachine.splicer.info=The Splicer is an incredibly powerful machine that is used to insert genes into individuals. This process is fast, but requires monumental amounts of power.
 genetics.machine.splicer.error.noIndividual=No Individual to Splice


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.

Also fixes "Carpentry Hammer" / "Master Carpentry Hammer" being reverse.