### PR TITLE
Fix stained block hardness

### DIFF
--- a/src/main/java/binnie/botany/ceramic/BlockStained.java
+++ b/src/main/java/binnie/botany/ceramic/BlockStained.java
@@ -34,6 +34,7 @@ public class BlockStained extends Block implements IBlockMetadata {
 
     public BlockStained() {
         super(Material.glass);
+        setHardness(0.3f);
         setCreativeTab(CreativeTabBotany.instance);
         setBlockName("stained");
     }


### PR DESCRIPTION
Fixed stained block having a hardness of 0, causing it to be insta-mineable by hand. Adjusted to `0.3f`, which matches vanilla Glass