### PR TITLE
Extend Lab Stand GUI width by 80 units

### DIFF
--- a/src/main/java/binnie/genetics/craftgui/WindowGeneBank.java
+++ b/src/main/java/binnie/genetics/craftgui/WindowGeneBank.java
@@ -46,7 +46,7 @@ public class WindowGeneBank extends WindowMachine {
     protected ControlGeneScroll genes;
 
     public WindowGeneBank(EntityPlayer player, IInventory inventory, Side side, boolean isNEI) {
-        super(320, 224, player, inventory, side);
+        super(400, 224, player, inventory, side);
         isNei = isNEI;
     }
 
@@ -100,7 +100,7 @@ public class WindowGeneBank extends WindowMachine {
         new ControlPlayerInventory(this, x, y);
         x += 124;
         boxX = x;
-        int geneBoxWidth = 120;
+        int geneBoxWidth = 200;
         new Panel(this, boxX + 24, 32.0f, geneBoxWidth, 120.0f, MinecraftGUI.PanelType.Black);
         new Panel(this, boxX + 24 + geneBoxWidth, 32.0f, 14.0f, 120.0f, MinecraftGUI.PanelType.Gray);
         ControlScrollableContent scroll = new ControlScrollableContent(


### PR DESCRIPTION
Lab Stand may feel pretty cramped once you gather bigger number of genes. The goal is of this PR is to extend its GUI width by 80 units horizontally

Before (1440p, from GUI Scale Small to Auto)
![2025-05-07_00 38 36](https://github.com/user-attachments/assets/95ac1f6d-e1d8-4a4e-9568-3d5efea18a8a)
![2025-05-07_00 38 41](https://github.com/user-attachments/assets/5542a05e-4ab6-40e4-8fb2-d6786679efb6)
![2025-05-07_00 38 45](https://github.com/user-attachments/assets/9b2d8a7b-cda1-4dd2-b1a9-c4735a716e8e)
![2025-05-07_00 38 50](https://github.com/user-attachments/assets/3f9d4652-e27f-417a-b366-ed6742872e2f)

After (1440p, from GUI Scale Small to Auto)
![2025-05-07_00 40 23](https://github.com/user-attachments/assets/d897ac17-c0bd-4438-9b7d-3ae47fc7f483)
![2025-05-07_00 40 29](https://github.com/user-attachments/assets/8897cd87-238a-40fb-b065-971d8897438a)
![2025-05-07_00 40 32](https://github.com/user-attachments/assets/c46b9d6d-5c82-4de2-9450-e13f3a5432bd)
![2025-05-07_00 40 37](https://github.com/user-attachments/assets/0249cde1-aa4f-4585-88fe-2cf1076ce948)

Tested with various window sizes and GUI Scales, nothing breaks