### PR TITLE
Remove mutator mutation chance cap

### DIFF
--- a/src/main/java/binnie/extrabees/apiary/machine/mutator/MutatorModifierComponent.java
+++ b/src/main/java/binnie/extrabees/apiary/machine/mutator/MutatorModifierComponent.java
@@ -18,8 +18,7 @@ public class MutatorModifierComponent extends ComponentBeeModifier implements IB
             return 1.0f;
         }
 
-        float mult = AlvearyMutator.getMutationMult(getUtil().getStack(AlvearyMutator.SLOT_MUTATOR));
-        return Math.min(mult, 15.0f / currentModifier);
+        return AlvearyMutator.getMutationMult(getUtil().getStack(AlvearyMutator.SLOT_MUTATOR));
     }
 
     @Override


### PR DESCRIPTION
This method meant that having a mutator present and active will cap _all_ mutation chance to 15x. This made the block essentially unviable because other methods could push well beyond the 15x cap, and trying some strategy involving the mutator with other methods was essentially worthless and called out on the definitive wiki guide for bee breeding as DO NOT USE.

If mutation chance should be capped, it should be done in Forestry, at the end of all mutation math. As it stands right now, this adds a workable alternative to frenzy frames (when it comes to mutation chance).