### PR TITLE
Fix mutator not accepting items listed on the wiki

### DIFF
--- a/src/main/java/binnie/extrabees/apiary/ModuleApiary.java
+++ b/src/main/java/binnie/extrabees/apiary/ModuleApiary.java
@@ -34,12 +34,12 @@ public class ModuleApiary implements IInitializable {
                 BinnieCore.proxy.createObject("binnie.core.machines.RendererMachine"));
         ModuleApiary.blockComponent = machineGroup.getBlock();
         AlvearyMutator.addMutationItem(new ItemStack(Blocks.soul_sand), 1.5f);
-        AlvearyMutator.addMutationItem(Mods.ic2.stack("UranFuel"), 8.0f);
-        AlvearyMutator.addMutationItem(Mods.ic2.stack("Plutonium"), 15.0f);
-        AlvearyMutator.addMutationItem(Mods.ic2.stack("smallPlutonium"), 9.0f);
-        AlvearyMutator.addMutationItem(Mods.ic2.stack("Uran235"), 10.0f);
-        AlvearyMutator.addMutationItem(Mods.ic2.stack("smallUran235"), 5.5f);
-        AlvearyMutator.addMutationItem(Mods.ic2.stack("Uran238"), 2.0f);
+        AlvearyMutator.addMutationItem(Mods.ic2.stack("itemUran"), 8.0f);
+        AlvearyMutator.addMutationItem(Mods.ic2.stack("itemPlutonium"), 15.0f);
+        AlvearyMutator.addMutationItem(Mods.ic2.stack("itemPlutoniumSmall"), 9.0f);
+        AlvearyMutator.addMutationItem(Mods.ic2.stack("itemUran235"), 10.0f);
+        AlvearyMutator.addMutationItem(Mods.ic2.stack("itemUran235small"), 5.5f);
+        AlvearyMutator.addMutationItem(Mods.ic2.stack("itemUran238"), 2.0f);
         AlvearyMutator.addMutationItem(new ItemStack(Items.nether_star), 50.0f);
         AlvearyMutator.addMutationItem(new ItemStack(Items.ender_pearl), 2.0f);
         AlvearyMutator.addMutationItem(new ItemStack(Items.ender_eye), 4.0f);


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20957

This was just a matter of the IC2 item stack names being wrong, the UI does a look a little weird now though because all the mutagens work properly.

The mutator now accepts the items listed here https://wiki.gtnewhorizons.com/wiki/Bees#Tips_and_Tricks.

Nether is not listed on the wiki but is in the code so I'll get someone to add Nether Star to the list on the wiki.

<img width="1442" height="1429" alt="image" src="https://github.com/user-attachments/assets/0052e16e-7cfb-4289-bae5-a1a589391070" />
