### PR TITLE
Fix metadata error when using Scooporator MX200 Turbo

### DIFF
--- a/src/main/java/binnie/extrabees/worldgen/BlockExtraBeeHive.java
+++ b/src/main/java/binnie/extrabees/worldgen/BlockExtraBeeHive.java
@@ -99,8 +99,7 @@ public class BlockExtraBeeHive extends Block {
     }
 
     @Override
-    public int getDamageValue(World world, int x, int y, int z) {
-        int meta = world.getBlockMetadata(x, y, z);
+    public int damageDropped(int meta) {
         return meta;
     }
 }

--- a/src/main/java/binnie/extrabees/worldgen/BlockExtraBeeHive.java
+++ b/src/main/java/binnie/extrabees/worldgen/BlockExtraBeeHive.java
@@ -97,4 +97,10 @@ public class BlockExtraBeeHive extends Block {
         }
         return ret;
     }
+
+    @Override
+    public int getDamageValue(World world, int x, int y, int z) {
+        int meta = world.getBlockMetadata(x, y, z);
+        return meta;
+    }
 }


### PR DESCRIPTION
MX200 is actually using `Block#getDamageValue` to get the hive type

https://github.com/GTNewHorizons/gendustry/blob/73501e7e77d872487ff74b327e381fe4554a1b22/src/main/scala/net/bdew/gendustry/items/IndustrialScoop.scala#L80C39-L80C53

fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21369