### PR TITLE
Only send NEI keybinds when no widget is focused

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,7 +4,7 @@ dependencies {
     api('com.github.GTNewHorizons:ForestryMC:4.11.12:dev')
     implementation('com.github.GTNewHorizons:GTNHLib:0.9.48:dev')
 
-    devOnlyNonPublishable('com.github.GTNewHorizons:NotEnoughItems:2.8.88-GTNH:dev')
+    devOnlyNonPublishable('com.github.GTNewHorizons:NotEnoughItems:2.8.97-GTNH:dev')
 
     compileOnly('com.github.GTNewHorizons:BuildCraft:7.1.57:api')
     compileOnly('net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev')

--- a/src/main/java/binnie/core/craftgui/minecraft/GuiCraftGUI.java
+++ b/src/main/java/binnie/core/craftgui/minecraft/GuiCraftGUI.java
@@ -240,12 +240,16 @@ public class GuiCraftGUI extends GuiContainer {
 
     @Override
     protected void keyTyped(char c, int key) {
-        NEIHook.lastKeyTyped(key, c);
+        boolean noFocusedWidget = window.getFocusedWidget() == null;
 
-        if (key == 1 || (key == mc.gameSettings.keyBindInventory.getKeyCode() && window.getFocusedWidget() == null)) {
+        if (noFocusedWidget) {
+            NEIHook.lastKeyTyped(key, c);
+        }
+
+        if (key == 1 || (key == mc.gameSettings.keyBindInventory.getKeyCode() && noFocusedWidget)) {
             mc.thePlayer.closeScreen();
         }
-        IWidget origin = (window.getFocusedWidget() == null) ? window : window.getFocusedWidget();
+        IWidget origin = noFocusedWidget ? window : window.getFocusedWidget();
         window.callEvent(new EventKey.Down(origin, c, key));
     }
 


### PR DESCRIPTION
Otherwise they trigger while searching in the compartment