### PR TITLE
[Memory-opti:fix leak] fix world client leak caused by static CraftGUI

### DIFF
--- a/src/main/java/binnie/core/craftgui/minecraft/Window.java
+++ b/src/main/java/binnie/core/craftgui/minecraft/Window.java
@@ -267,7 +267,9 @@ public abstract class Window extends TopLevelWidget implements INetwork.ReceiveG
         entityInventory = inventory;
     }
 
-    public void onClose() {}
+    public void onClose() {
+        CraftGUI.render = null;
+    }
 
     public boolean isServer() {
         return !isClient();


### PR DESCRIPTION
<img width="498" height="177" alt="image" src="https://github.com/user-attachments/assets/7104518e-6326-4b2d-b68f-193a40c28160" />
