### PR TITLE
fix CraftGUI.render going null on GUI open/reopen

### DIFF
--- a/src/main/java/binnie/core/craftgui/WindowFieldKit.java
+++ b/src/main/java/binnie/core/craftgui/WindowFieldKit.java
@@ -188,7 +188,9 @@ public class WindowFieldKit extends Window {
         glassOffsetX *= 1.0f - analyseProgress;
         glassOffsetY += glassVY;
         glassOffsetY *= 1.0f - analyseProgress;
-        GlassControl.setOffset(new IPoint(glassOffsetX, glassOffsetY));
+        if (GlassControl != null) {
+            GlassControl.setOffset(new IPoint(glassOffsetX, glassOffsetY));
+        }
     }
 
     private void refreshSpecies() {

--- a/src/main/java/binnie/core/craftgui/minecraft/Window.java
+++ b/src/main/java/binnie/core/craftgui/minecraft/Window.java
@@ -85,8 +85,7 @@ public abstract class Window extends TopLevelWidget implements INetwork.ReceiveG
         }
 
         renderer = new Renderer(gui);
-        CraftGUI.render = renderer;
-        CraftGUI.render.stylesheet(StyleSheetManager.getDefault());
+        renderer.stylesheet(StyleSheetManager.getDefault());
         titleButtonLeft = -14.0f;
 
         if (showHelpButton()) {
@@ -197,8 +196,7 @@ public abstract class Window extends TopLevelWidget implements INetwork.ReceiveG
     }
 
     public void initGui() {
-        // Restore the renderer every time the screen is (re-)shown,
-        // e.g. after returning from a NEI sub-screen that called onClose().
+
         CraftGUI.render = renderer;
 
         if (hasBeenInitialised) {
@@ -274,12 +272,7 @@ public abstract class Window extends TopLevelWidget implements INetwork.ReceiveG
     }
 
     public void onClose() {
-        // Only clear the renderer if it still belongs to this window,
-        // preventing a race where the new window's renderer is nulled
-        // before initGui() runs (introduced by the world-client leak fix).
-        if (CraftGUI.render == renderer) {
-            CraftGUI.render = null;
-        }
+        CraftGUI.render = null;
     }
 
     public boolean isServer() {

--- a/src/main/java/binnie/core/craftgui/minecraft/Window.java
+++ b/src/main/java/binnie/core/craftgui/minecraft/Window.java
@@ -53,6 +53,7 @@ public abstract class Window extends TopLevelWidget implements INetwork.ReceiveG
     protected float titleButtonLeft;
     protected float titleButtonRight;
     private GuiCraftGUI gui;
+    private Renderer renderer;
     private final ContainerCraftGUI container;
     private final WindowInventory windowInventory;
     private ControlText title;
@@ -83,7 +84,8 @@ public abstract class Window extends TopLevelWidget implements INetwork.ReceiveG
             ControlSlot.highlighting.put(h, new ArrayList<>());
         }
 
-        CraftGUI.render = new Renderer(gui);
+        renderer = new Renderer(gui);
+        CraftGUI.render = renderer;
         CraftGUI.render.stylesheet(StyleSheetManager.getDefault());
         titleButtonLeft = -14.0f;
 
@@ -195,6 +197,10 @@ public abstract class Window extends TopLevelWidget implements INetwork.ReceiveG
     }
 
     public void initGui() {
+        // Restore the renderer every time the screen is (re-)shown,
+        // e.g. after returning from a NEI sub-screen that called onClose().
+        CraftGUI.render = renderer;
+
         if (hasBeenInitialised) {
             return;
         }
@@ -268,7 +274,12 @@ public abstract class Window extends TopLevelWidget implements INetwork.ReceiveG
     }
 
     public void onClose() {
-        CraftGUI.render = null;
+        // Only clear the renderer if it still belongs to this window,
+        // preventing a race where the new window's renderer is nulled
+        // before initGui() runs (introduced by the world-client leak fix).
+        if (CraftGUI.render == renderer) {
+            CraftGUI.render = null;
+        }
     }
 
     public boolean isServer() {

--- a/src/main/java/binnie/core/craftgui/renderer/Renderer.java
+++ b/src/main/java/binnie/core/craftgui/renderer/Renderer.java
@@ -30,6 +30,10 @@ public class Renderer {
         this.gui = gui;
     }
 
+    public GuiCraftGUI getGui() {
+        return gui;
+    }
+
     public void preRender(IWidget widget) {
         GL11.glPushMatrix();
         GL11.glTranslatef(widget.getPosition().x(), widget.getPosition().y(), 0.0f);

--- a/src/main/java/binnie/core/craftgui/renderer/Renderer.java
+++ b/src/main/java/binnie/core/craftgui/renderer/Renderer.java
@@ -30,10 +30,6 @@ public class Renderer {
         this.gui = gui;
     }
 
-    public GuiCraftGUI getGui() {
-        return gui;
-    }
-
     public void preRender(IWidget widget) {
         GL11.glPushMatrix();
         GL11.glTranslatef(widget.getPosition().x(), widget.getPosition().y(), 0.0f);


### PR DESCRIPTION
onClose() from #95 nulled CraftGUI.render unconditionally, wiping the renderer set by a new window before its initGui() ran. Returning from NEI sub-screens also crashed since hasBeenInitialised skipped re-init without restoring the renderer. Fixed by storing Renderer in the Window instance and restoring CraftGUI.render at the start of every initGui().
Fixes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24817
Fixes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24821