### PR TITLE
Fix ComponentTankContainer draining wrong fluid when specific fluid requested

### DIFF
--- a/src/main/java/binnie/core/machines/inventory/ComponentTankContainer.java
+++ b/src/main/java/binnie/core/machines/inventory/ComponentTankContainer.java
@@ -164,7 +164,7 @@ public class ComponentTankContainer extends MachineComponent implements ITankMac
 
     @Override
     public FluidStack drain(ForgeDirection from, FluidStack resource, boolean doDrain) {
-        int index = getTankIndexToDrain(from, null);
+        int index = getTankIndexToDrain(from, resource);
         if (!tanks.containsKey(index)) {
             return null;
         }


### PR DESCRIPTION
Closes GTNewHorizons/GT-New-Horizons-Modpack#24843

## Summary

- `ComponentTankContainer.drain(ForgeDirection, FluidStack, boolean)` was calling `getTankIndexToDrain(from, null)` instead of `getTankIndexToDrain(from, resource)`, causing it to ignore the requested fluid type and drain from the first available tank regardless of its contents
- `canDrain(ForgeDirection, Fluid)` delegates to this same method, so it also incorrectly returned `true` for fluids that weren't actually drainable
- This caused AE2 storage buses to receive a different fluid than the one requested, leading to the dupe/loss exploit reported in GTNewHorizons/GT-New-Horizons-Modpack#24843