### PR TITLE
Fix uninitialized inventory slot and create slot

### DIFF
--- a/src/main/java/binnie/genetics/gui/WindowAnalyst.java
+++ b/src/main/java/binnie/genetics/gui/WindowAnalyst.java
@@ -116,6 +116,7 @@ public class WindowAnalyst extends Window {
                 tracker.synchToPlayer(getPlayer());
             }
         }
+        getWindowInventory().createSlot(0);
         setupValidators();
         getWindowInventory().createSlot(0);
     }

--- a/src/main/java/binnie/genetics/gui/WindowAnalyst.java
+++ b/src/main/java/binnie/genetics/gui/WindowAnalyst.java
@@ -117,6 +117,7 @@ public class WindowAnalyst extends Window {
             }
         }
         getWindowInventory().createSlot(0);
+        getWindowInventory().createSlot(1);
         setupValidators();
         getWindowInventory().createSlot(0);
     }

--- a/src/main/java/binnie/genetics/gui/WindowAnalyst.java
+++ b/src/main/java/binnie/genetics/gui/WindowAnalyst.java
@@ -117,6 +117,7 @@ public class WindowAnalyst extends Window {
             }
         }
         setupValidators();
+        getWindowInventory().createSlot(0);
     }
 
     @Override


### PR DESCRIPTION
## Summary
A bug where if you shift left click the genetic dyes in the Analyst tool, after analysis both the bee and genetic dye would turn into ghost item and be returned to you and bee description would still say it was not analyzed. This 2 lines PR makes the server knows that the GUI slot existed and insert it appropriately when shift left clicking. Oddly enough shift left clicking a stack with only one dyes works along side manually left click and drag the whole stack into the slot.


## Checklist
- [X] I have tested this PR in DevEnv
- [X] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge