### PR TITLE
Don't interact with energy net on client side

### DIFF
--- a/src/main/java/binnie/core/machines/power/ComponentPowerReceptor.java
+++ b/src/main/java/binnie/core/machines/power/ComponentPowerReceptor.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.ForgeDirection;
 
@@ -152,7 +153,8 @@ public class ComponentPowerReceptor extends MachineComponent
     }
 
     private void addToEnergyNet() {
-        if (getMachine().getWorld() == null) {
+        World world = getMachine().getWorld();
+        if (world == null || world.isRemote) {
             return;
         }
         if (Mods.ic2.active()) {
@@ -161,7 +163,8 @@ public class ComponentPowerReceptor extends MachineComponent
     }
 
     private void removeFromEnergyNet() {
-        if (getMachine().getWorld() == null) {
+        World world = getMachine().getWorld();
+        if (world == null || world.isRemote) {
             return;
         }
         if (Mods.ic2.active()) {


### PR DESCRIPTION
## Summary
Fixes <https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26211>

This should not happen on the client side.


## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
